### PR TITLE
Integrate ibench_native, add license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 rscohn2
+Copyright (c) 2016-2018 Intel Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,18 +3,34 @@
 Benchmarks for Intel Distribution for Python
 
 ## Install
-        # Since you want to benchmark numpy/scipy, manually install the one you want
-        # instead of letting pip install one
-        # cython is needed to build native extensions in ibench_native
-        conda install scipy cython
-        pip install -e .
+```bash
+# Since you want to benchmark numpy/scipy, manually install the one you want
+# instead of letting pip install one
+# cython is needed to build native extensions in ibench_native
+conda install scipy cython scikit-learn
+pip install -v --upgrade .
+```
+
+### Native versions
+If `icc` and `cython` are available during the build, they will be used
+to build native benchmarks. To specify a different compiler, specify one
+in the environment variable `CXX`.
 
 ## Run
-        # basic command
-        python -m ibench run -b all --size large --runs 3 --file all.out
-        # Use ibench_native plugin to include native versions of the benchmarks. See the ibench_native repository
-        IBENCH_PLUGINS=ibench_native python -m ibench run -b dot_native --size large --runs 3 --file all.out
+```bash
+# basic command
+python -m ibench run -b all --size large --runs 3 --file all.out
+```
+
+### Specifying benchmarks
+- To run one or multiple benchmarks, pass the `-b BENCHMARKS...` option.
+  Benchmarks can be specified individually, or in predefined groups
+  (e.g. `native` contains all native benchmarks)
+- To specify the problem size, use the `--size` option. This selects
+  from a list of predefined problem sizes.
 
 ## Help
-        python -m ibench --help
-        python -m ibench run --help
+```bash
+python -m ibench --help
+python -m ibench run --help
+```

--- a/conda/build.bat
+++ b/conda/build.bat
@@ -1,1 +1,5 @@
+REM Copyright (C) 2016 Intel Corporation
+REM
+REM SPDX-License-Identifier: MIT
+
 python setup.py install

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,1 +1,5 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 python setup.py install

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 package:
   name: ibench
   version: 0.1rc

--- a/conda/run_test.py
+++ b/conda/run_test.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import subprocess
 
 subprocess.run('python -m pytest tests', shell=True, check=True)

--- a/example/NERSC/run_ibench_hsw.sl
+++ b/example/NERSC/run_ibench_hsw.sl
@@ -1,5 +1,9 @@
 #!/bin/bash -l
 
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 #SBATCH -N 1               
 #SBATCH -p regular
 #SBATCH -t 00:45:00

--- a/example/NERSC/run_ibench_knl_cache.sl
+++ b/example/NERSC/run_ibench_knl_cache.sl
@@ -1,5 +1,9 @@
 #!/bin/bash -l
 
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 #SBATCH -N 1               
 #SBATCH -p regular
 #SBATCH -t 00:45:00

--- a/example/NERSC/setup_environment.sh
+++ b/example/NERSC/setup_environment.sh
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 # set up script on NERSC Cori machine 
 module load python/3.5-anaconda
 if [[ ! -d $HOME/.conda ]]; then

--- a/ibench/__main__.py
+++ b/ibench/__main__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import argparse
 import os
 import sys

--- a/ibench/benchmarks/__init__.py
+++ b/ibench/benchmarks/__init__.py
@@ -49,3 +49,9 @@ benchmark_groups = {
                   'rng', 'lregression', 'lregressionfit', 'ridge',
                   'ridgefit','cosine','corr','svm','kmeans','kmeansfit']
 }
+
+# Try to get native benchmarks
+try:
+    from .. import native
+except ImportError:
+    pass

--- a/ibench/benchmarks/__init__.py
+++ b/ibench/benchmarks/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from . import cholesky
 from . import det
 from . import dot

--- a/ibench/benchmarks/bench.py
+++ b/ibench/benchmarks/bench.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import print_function
 import gc
 import numpy as np

--- a/ibench/benchmarks/blacksch.py
+++ b/ibench/benchmarks/blacksch.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 from numpy import log, exp
 from .bench import Bench

--- a/ibench/benchmarks/cholesky.py
+++ b/ibench/benchmarks/cholesky.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2017 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import scipy.linalg
 

--- a/ibench/benchmarks/corr.py
+++ b/ibench/benchmarks/corr.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn
 import multiprocessing

--- a/ibench/benchmarks/cosine.py
+++ b/ibench/benchmarks/cosine.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn
 import multiprocessing

--- a/ibench/benchmarks/det.py
+++ b/ibench/benchmarks/det.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2017 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import scipy
 

--- a/ibench/benchmarks/dot.py
+++ b/ibench/benchmarks/dot.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2017 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 
 from .bench import Bench

--- a/ibench/benchmarks/fft.py
+++ b/ibench/benchmarks/fft.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import math
 import numpy as np
 import scipy.fftpack

--- a/ibench/benchmarks/inv.py
+++ b/ibench/benchmarks/inv.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2017 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import scipy
 

--- a/ibench/benchmarks/kmeans.py
+++ b/ibench/benchmarks/kmeans.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn
 import multiprocessing

--- a/ibench/benchmarks/kmeansfit.py
+++ b/ibench/benchmarks/kmeansfit.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn
 import multiprocessing

--- a/ibench/benchmarks/lregression.py
+++ b/ibench/benchmarks/lregression.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn
 import multiprocessing

--- a/ibench/benchmarks/lregressionfit.py
+++ b/ibench/benchmarks/lregressionfit.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import sklearn
 import numpy as np
 import multiprocessing

--- a/ibench/benchmarks/lu.py
+++ b/ibench/benchmarks/lu.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import scipy
 

--- a/ibench/benchmarks/qr.py
+++ b/ibench/benchmarks/qr.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2017 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import scipy
 

--- a/ibench/benchmarks/ridge.py
+++ b/ibench/benchmarks/ridge.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn
 import multiprocessing

--- a/ibench/benchmarks/ridgefit.py
+++ b/ibench/benchmarks/ridgefit.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn
 import multiprocessing

--- a/ibench/benchmarks/rng.py
+++ b/ibench/benchmarks/rng.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 
 from .bench import Bench

--- a/ibench/benchmarks/svd.py
+++ b/ibench/benchmarks/svd.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2017 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import scipy.linalg
 

--- a/ibench/benchmarks/svm.py
+++ b/ibench/benchmarks/svm.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import numpy as np
 import sklearn, sklearn.utils
 import sklearn.svm as svm

--- a/ibench/cmds/cmd.py
+++ b/ibench/cmds/cmd.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import print_function
 import sys
 

--- a/ibench/cmds/configs.py
+++ b/ibench/cmds/configs.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2017 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import argparse
 
 

--- a/ibench/cmds/run.py
+++ b/ibench/cmds/run.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import print_function
 
 import argparse

--- a/ibench/configs/__init__.py
+++ b/ibench/configs/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from . import conda_py2
 from . import direct
 from . import idp201700

--- a/ibench/configs/conda_py2.py
+++ b/ibench/configs/conda_py2.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import subprocess
 import sys
 

--- a/ibench/configs/config.py
+++ b/ibench/configs/config.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import print_function
 import datetime
 import os

--- a/ibench/configs/direct.py
+++ b/ibench/configs/direct.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import sys
 
 from  .config import Config

--- a/ibench/configs/idp201700.py
+++ b/ibench/configs/idp201700.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from  .pip import Pip
 
 class IDP201700(Pip):

--- a/ibench/configs/idp201701.py
+++ b/ibench/configs/idp201701.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from  .pip import Pip
 
 class IDP201701(Pip):

--- a/ibench/configs/pip.py
+++ b/ibench/configs/pip.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from  .config import Config
 from  ..docker.build import build as dbuild
 

--- a/ibench/docker/Dockerfile.tpl
+++ b/ibench/docker/Dockerfile.tpl
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 {% if os_name == "centos" %}
 
 {% elif os_name == "ubuntu" %}

--- a/ibench/docker/build.py
+++ b/ibench/docker/build.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import print_function
 
 import argparse

--- a/ibench/native/__init__.py
+++ b/ibench/native/__init__.py
@@ -1,0 +1,24 @@
+# python loads libraries with RTLD_LOCAL, but MKL requires RTLD_GLOBAL
+# pre-load MKL with RTLD_GLOBAL before loading the native extension
+import ctypes
+try:
+    ctypes.CDLL('libmkl_rt.so', ctypes.RTLD_GLOBAL)
+except OSError:
+    raise ImportError
+
+from ibench.benchmarks import benchmarks, benchmark_groups
+from . import det
+from . import dot
+from . import inv
+from . import lu
+
+local_benchmarks = {
+    'dot_native': dot.Dot,
+    'det_native': det.Det,
+    'inv_native': inv.Inv,
+    'lu_native': lu.Lu
+}
+
+# add to the list of benchmark options
+benchmarks.update(local_benchmarks)
+benchmark_groups['native'] = local_benchmarks

--- a/ibench/native/__init__.py
+++ b/ibench/native/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016, 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 # python loads libraries with RTLD_LOCAL, but MKL requires RTLD_GLOBAL
 # pre-load MKL with RTLD_GLOBAL before loading the native extension
 import ctypes

--- a/ibench/native/c/bench.h
+++ b/ibench/native/c/bench.h
@@ -1,0 +1,74 @@
+#include <algorithm>
+
+using namespace std;
+  
+
+#include "assert.h"
+#include "stdlib.h"
+
+#if defined(__INTEL_COMPILER)
+
+#include "mkl.h"
+
+class Random{
+ private:
+  enum {SEED = 77777};
+  static double const d_zero = 0.0, d_one = 1.0;
+  VSLStreamStatePtr stream;
+
+ public:
+  Random() {
+    int err = vslNewStream(&stream, VSL_BRNG_MT19937, SEED);
+    assert(err == VSL_STATUS_OK);
+  }
+  ~Random() {
+    int err = vslDeleteStream(&stream);
+    assert(err == VSL_STATUS_OK);
+  }
+  void init_mat(double* mat, int size) {
+    int err = vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, size, mat, d_zero, d_one);
+    assert(err == VSL_STATUS_OK);
+  }
+};
+
+#else
+
+#include "lapacke.h"
+#include "cblas.h"
+
+class Random {
+ public:
+  void init_mat(double* mat, int size) {
+  }
+};
+
+static void* mkl_malloc(int size, int align) {
+   return malloc(size);
+}
+
+static void mkl_free(void*p) {
+    free(p);
+}
+#endif
+
+
+class Bench {
+ private:
+  Random random;
+ public:
+
+  double* make_random_mat(int size) {
+    double* mat = make_mat(size);
+    random.init_mat(mat,size);
+    return mat;
+  }
+
+  double* make_mat(int mat_size) {
+    double *mat = (double *) mkl_malloc(mat_size * sizeof(double), 64);
+    assert(mat);
+    return mat;
+  }
+
+
+  virtual void compute()=0;
+};

--- a/ibench/native/c/bench.h
+++ b/ibench/native/c/bench.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <algorithm>
 
 using namespace std;

--- a/ibench/native/c/det.h
+++ b/ibench/native/c/det.h
@@ -1,0 +1,60 @@
+#include "bench.h"
+
+class det_C : public Bench {
+ public:
+  det_C();
+  ~det_C();
+  void make_args(int size);
+  void compute();
+ private:
+  double *x_mat, *r_mat;
+  int *ipiv;
+  int n,m,lda;
+  int mn_min;
+  double result;
+};
+
+det_C::det_C() {
+  r_mat = 0;
+  ipiv = 0;
+  x_mat = 0;
+}
+
+void
+det_C::make_args(int size) {
+  n = size;
+  m = size;
+  mn_min = min(m, n);
+  lda = size;
+  int mat_size = m*n;
+  assert(m == n);
+
+  /* input matrix */
+  x_mat = make_random_mat(mat_size);
+
+  /* list of pivots */
+  ipiv = (int *) mkl_malloc(mn_min * sizeof(int), 64);
+  assert(ipiv);
+
+  /* matrix for result */
+  r_mat = make_random_mat(mat_size);
+}
+
+void det_C::compute() {
+  /* compute pivoted lu decomposition */
+  int info = LAPACKE_dgetrf(LAPACK_ROW_MAJOR, m, n, r_mat, lda, ipiv);
+  assert(info == 0);
+
+  double t = 1.0;
+  int i,j;
+  for(i=0, j=0; i < mn_min; i++, j+= lda+1) {
+    t *= (ipiv[i]==i) ? r_mat[j] : -r_mat[j];
+  }
+  result = t;
+}
+
+det_C::~det_C() {
+  if (r_mat) mkl_free(r_mat);
+  if (ipiv) mkl_free(ipiv);
+  if (x_mat) mkl_free(x_mat);
+}

--- a/ibench/native/c/det.h
+++ b/ibench/native/c/det.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "bench.h"
 
 class det_C : public Bench {

--- a/ibench/native/c/dot.h
+++ b/ibench/native/c/dot.h
@@ -1,0 +1,39 @@
+#include "bench.h"
+
+class dot_C : public Bench {
+ public:
+  dot_C() {
+    a_mat = 0;
+    b_mat = 0;
+    r_mat = 0;
+  }
+
+  ~dot_C() {
+    if (a_mat)
+      mkl_free(a_mat);
+    if (b_mat)
+      mkl_free(b_mat);
+    if (r_mat)
+      mkl_free(r_mat);
+  }
+
+  void make_args(int size) {
+    m = n = k = size;
+    
+    a_mat = make_random_mat(m*k);
+    b_mat = make_random_mat(k*n);
+    r_mat = make_random_mat(m*n);
+  }
+
+  void compute() {
+    double alpha = 1.0; 
+    double beta = 0.0;
+
+    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, 
+                n, n, k, alpha, a_mat, k, b_mat, n, beta, r_mat, n);
+  }
+
+ private:
+  double *a_mat, *b_mat, *r_mat;
+  int m,n,k;
+};

--- a/ibench/native/c/dot.h
+++ b/ibench/native/c/dot.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "bench.h"
 
 class dot_C : public Bench {

--- a/ibench/native/c/inv.h
+++ b/ibench/native/c/inv.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "bench.h"
 
 class inv_C : public Bench {

--- a/ibench/native/c/inv.h
+++ b/ibench/native/c/inv.h
@@ -1,0 +1,52 @@
+#include "bench.h"
+
+class inv_C : public Bench {
+ public:
+  inv_C() {
+    x_mat = 0;
+    r_mat = 0;
+    ipiv = 0;
+  }
+
+  ~inv_C() {
+    if (r_mat)
+      mkl_free(r_mat);
+    if (ipiv)
+      mkl_free(ipiv);
+    if (x_mat)
+      mkl_free(x_mat);
+  }
+
+  void make_args(int size) {
+    N = size;
+    M = size;
+    LDA = size;
+    int mat_size = M*N, mn_min = min(M, N);
+
+    assert(M == N);
+
+    /* input matrix */
+    x_mat = make_random_mat(mat_size);
+
+    /* list of pivots */
+    ipiv = (int *) mkl_malloc(mn_min * sizeof(int), 64);
+    assert(ipiv);
+
+    /* matrix for result */
+    r_mat = make_random_mat(mat_size);
+  }
+
+  void compute() {
+    /* compute pivoted lu decomposition */
+    int info = LAPACKE_dgetrf(LAPACK_ROW_MAJOR, M, N, r_mat, LDA, ipiv);
+    assert(info == 0);
+
+    info = LAPACKE_dgetri(LAPACK_ROW_MAJOR, N, r_mat, LDA, ipiv);
+    assert(info == 0);
+  }
+
+ private:
+  double *x_mat, *r_mat;
+  int *ipiv;
+  int N,M,LDA;
+};

--- a/ibench/native/c/lu.h
+++ b/ibench/native/c/lu.h
@@ -1,0 +1,103 @@
+#include "bench.h"
+
+class lu_C : public Bench {
+ public:
+  lu_C();
+  ~lu_C();
+  void make_args(int size);
+  void compute();
+
+ private:
+  int *ipiv;
+  double *x_mat, *r_mat, *l_mat, *u_mat, *p_mat;
+  int m,n,lda,mn_min;
+  int l_size, u_size, p_size;
+};
+
+
+lu_C::lu_C() {
+  x_mat = r_mat = l_mat = u_mat = p_mat = 0;
+}
+
+void
+lu_C::make_args(int size) {
+  m = n = lda = size;
+
+  int mat_size = m*n;
+  int r_size = mat_size, 
+
+  mn_min = min(m, n);
+  l_size = m*mn_min;
+  u_size = mn_min*n;
+  p_size = m*m;
+
+  /* input matrix */
+  x_mat = make_random_mat(mat_size);
+
+  /* list of pivots */
+  ipiv = (int *) mkl_malloc(mn_min * sizeof(int), 64);
+  assert(ipiv);
+
+  /* matrix for result */
+  r_mat = make_random_mat(r_size);
+
+  /* lower-triangular matrix */
+  l_mat = make_random_mat(l_size);
+
+  /* upper triangular matrix */
+  u_mat = make_random_mat(u_size);
+
+  /* permutation matrix */
+  p_mat = make_random_mat(p_size);
+
+  mkl_domatcopy('R', 'T', m, n, 1.0, x_mat, n, r_mat, m);
+  lda = m + n - lda;
+}
+
+void lu_C::compute() {
+  /* compute pivoted lu decomposition */
+  int info = LAPACKE_dgetrf(LAPACK_COL_MAJOR, m, n, r_mat, lda, ipiv);
+  assert(info == 0);
+
+  int ld_l = m;
+  int ld_u = mn_min;
+  int ld_p = m;
+  memset(l_mat, 0, l_size * sizeof(double));
+  memset(u_mat, 0, u_size * sizeof(double));
+
+  /* extract L and U matrix elements from r_mat */
+  #pragma ivdep
+  for(int i = 0; i < m; i++) {
+    #pragma ivdep
+    for(int j = 0; j < n; j++){
+      if (j < mn_min) {
+        if(i == j) {
+          l_mat[j * ld_l + i] = 1.0;
+        } else if (i > j) {
+          l_mat[j * ld_l + i] = r_mat[j * lda + i];
+        } 
+      }
+      if (i < mn_min) {
+        if(i <= j) 
+          u_mat[j * ld_u + i] = r_mat[j * lda + i];
+      }
+    }
+  }
+
+  /* make a diagonal matrix (m,m) */
+  memset(p_mat, 0, p_size * sizeof(double)); 
+  for(int i = 0; i < m; i++) p_mat[i*(m + 1)] = 1.0;    
+
+  info = LAPACKE_dlaswp(LAPACK_COL_MAJOR, m, p_mat, m, 1, mn_min, ipiv, -1);
+  assert(info == 0);
+}
+
+lu_C::~lu_C() {
+  if (l_mat) mkl_free(l_mat);
+  if (u_mat) mkl_free(u_mat);
+  if (r_mat) mkl_free(r_mat);
+  if (p_mat) mkl_free(p_mat);
+
+  if (ipiv) mkl_free(ipiv);
+  if (x_mat) mkl_free(x_mat);
+}

--- a/ibench/native/c/lu.h
+++ b/ibench/native/c/lu.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "bench.h"
 
 class lu_C : public Bench {

--- a/ibench/native/tpl.bench.pyx
+++ b/ibench/native/tpl.bench.pyx
@@ -1,0 +1,28 @@
+# distutils: language = c++
+
+from ibench.benchmarks.{{bench}} import {{Bench}}
+
+# Expose the C++ class
+cdef extern from '../ibench/native/c/{{bench}}.h':
+     cdef cppclass {{bench}}_C:
+        {{bench}}_C() except +
+        void make_args(int) except +
+        void compute() except +
+
+# Wrap the c++ class in an extension class
+# extension class cannot inherit from python classes
+cdef class Wrapper:
+    cdef {{bench}}_C c_class
+    def make_args(self,n):
+        self.c_class.make_args(n)
+    def compute(self):
+        self.c_class.compute()
+
+# Inherit from python bench with methods specific to native
+class {{Bench}}_native({{Bench}}):
+    def _make_args(self, n):
+        self._wrapper = Wrapper()
+        self._wrapper.make_args(n)
+
+    def _compute(self):
+        self._wrapper.compute()

--- a/ibench/native/tpl.bench.pyx
+++ b/ibench/native/tpl.bench.pyx
@@ -1,3 +1,7 @@
+# Copyright (C) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 # distutils: language = c++
 
 from ibench.benchmarks.{{bench}} import {{Bench}}

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,64 @@
+from __future__ import print_function
 from setuptools import setup
+
+
+def build_native():
+    '''Return cythonized extensions for native benchmarks'''
+    try:
+        # use icc if it is available
+        icc = subprocess.check_output('which icc',shell=True).decode('utf-8')
+    except:
+        icc = None
+        extra_args = []
+    else:
+        print('Using icc: %s' % icc)
+        os.environ['CC'] = icc
+        os.environ['CXX'] = os.environ['CC']
+        extra_args = ['-mkl']
+
+    if not 'CXX' in os.environ:
+        print('icc not detected, and CXX is not set. Skipping building native benchmarks.')
+        print('If you want to build native benchmarks, specify a compiler in the CXX '
+              'environment variable.')
+        return
+
+    try:
+        os.mkdir('pyx')
+    except OSError:
+        pass
+
+    def make_bench(name):
+        tpl_env = Environment(loader=FileSystemLoader('ibench/native'))
+        with open('pyx/%s.pyx' % name,'w') as pyxf:
+            pyxf.write(tpl_env.get_template('tpl.bench.pyx').render({'bench': name, 'Bench': name.capitalize()}))
+        return Extension(name='ibench.native.%s' % name,
+                         extra_compile_args=extra_args,
+                         extra_link_args=extra_args,
+                         sources=['pyx/%s.pyx' % name])
+
+    return cythonize([make_bench(i) for i in ['det', 'dot', 'inv', 'lu']])
+
+
+packages = ['ibench','ibench/docker','ibench/cmds','ibench/configs','ibench/benchmarks']
+
+
+try:
+    from Cython.Build import cythonize
+    from jinja2 import FileSystemLoader
+    from jinja2 import Environment
+    import os
+    from setuptools import Extension
+    import subprocess
+    import sys
+except ImportError:
+    print('Cython not found. Skipping building native benchmarks.')
+    extensions = None
+else:
+    # Cython and Jinja2 found in build environment. Look for compilers
+    extensions = build_native()
+    if extensions:
+        packages.append('ibench/native')
+
 
 setup(name='ibench',
       version='0.1rc',
@@ -8,7 +68,8 @@ setup(name='ibench',
       author='Robert Cohn',
       author_email='Robert.S.Cohn@intel.com',
       license='MIT',
-      packages=['ibench','ibench/docker','ibench/cmds','ibench/configs','ibench/benchmarks'],
-      install_requires=['jinja2','numpy','scipy'],
+      packages=packages,
+      install_requires=['jinja2','numpy','scipy','scikit-learn'],
+      ext_modules=extensions,
       package_data={'ibench': ['docker/Dockerfile.tpl']},
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016, 2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import print_function
 from setuptools import setup
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import subprocess
 
 def test_auto_size():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2016-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import subprocess
 
 def test_run_plugin():


### PR DESCRIPTION
Hi @triskadecaepyon @anton-malakhov 

- Add native versions of dot, det, lu, inv benchmarks from @rscohn2's ibench_native repo.
  - A user can run a native version of a benchmark by specifying `_native` after the benchmark name, which should be the name of the native version.
  - By default, setup.py will build native benchmarks only if Cython and icc are found. Please see updated README for details.
- Add license headers to each file and fix the copyright assignment to `Intel Corporation`
- Add scikit-learn as a dependency in setup.py. Running even `python -m ibench -h` fails unless scikit-learn is available.
  - Maybe a good idea would be not to import benchmarks requiring scikit-learn if the import fails. Then we can drop these dependencies or put them as extras.