### PR TITLE
Add CSV output, fix env info collection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2018 Intel Corporation
+Copyright (c) 2016-2019 Intel Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ibench/cmds/run.py
+++ b/ibench/cmds/run.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2018 Intel Corporation
+# Copyright (C) 2016-2019 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
@triskadecaepyon 

This PR adds basic CSV output support to `ibench run` and other features:
- Add argument `--no-get-env-info` to avoid environment information collection 
- Add argument `-f,--format` to select between JSON and CSV formats
- Add argument `--env-info-prefix` to specify the prefix which can be used to differentiate between env-related outputs and the actual CSV output.
- Fix decoding of `bytes` returned from `ibench.cmds.run.capture_multiline_output`.

As an example, I'm able to get the parsable outputs I want by running `python -m ibench run --name intelpython3 --no-get-env-info --format csv --quiet`.

All the default options will still use the old behavior of collecting all environment information and outputting JSON. The only difference in the output is the fixed decoding. (using `b.decode()` instead of `str(b)` where `type(b) is bytes`.)