### PR TITLE
Use F-contiguous arrays for QR, SVD

### DIFF
--- a/ibench/benchmarks/inv.py
+++ b/ibench/benchmarks/inv.py
@@ -23,4 +23,7 @@ class Inv(Bench):
         self._A = np.asfortranarray(np.random.rand(n,n), dtype=self._dtype)
 
     def _compute(self):
+        # yes, we overwrite the input here without refreshing it,
+        # but because (A**-1)**-1 = A, there shouldn't be any big problems
+        # w.r.t. early termination of inverse
         scipy.linalg.inv(self._A, overwrite_a=True, check_finite=False)

--- a/ibench/benchmarks/qr.py
+++ b/ibench/benchmarks/qr.py
@@ -7,14 +7,16 @@ import scipy
 
 from .bench import Bench
 
+
 class Qr(Bench):
-    sizes = {'large': 10000, 'small': 5000, 'tiny': 1000,'test': 2}
+    sizes = {'large': 10000, 'small': 5000, 'tiny': 1000, 'test': 2}
 
     def _ops(self, n):
         return (4./3.)*n*n*n*1e-9
 
     def _make_args(self, n):
-        self._A = np.asarray(np.random.rand(n,n), dtype=self._dtype)
+        self._A = np.asfortranarray(np.random.rand(n, n), dtype=self._dtype)
 
     def _compute(self):
-        scipy.linalg.qr(self._A, overwrite_a=True, check_finite=False, mode='raw')
+        scipy.linalg.qr(self._A, overwrite_a=True, check_finite=False,
+                        mode='raw')

--- a/ibench/benchmarks/svd.py
+++ b/ibench/benchmarks/svd.py
@@ -18,4 +18,6 @@ class Svd(Bench):
         self._A = np.asfortranarray(np.random.rand(n, n), dtype=self._dtype)
 
     def _compute(self):
-        scipy.linalg.svd(self._A, overwrite_a=True, check_finite=False)
+        # We specify overwrite_a=False here because once the input array
+        # is overwritten, dgesdd might decide to terminate early
+        scipy.linalg.svd(self._A, overwrite_a=False, check_finite=False)

--- a/ibench/benchmarks/svd.py
+++ b/ibench/benchmarks/svd.py
@@ -18,5 +18,4 @@ class Svd(Bench):
         self._A = np.asfortranarray(np.random.rand(n, n), dtype=self._dtype)
 
     def _compute(self):
-        scipy.linalg.svd(self._A, overwrite_a=True, check_finite=False,
-                         full_matrices=True)
+        scipy.linalg.svd(self._A, overwrite_a=True, check_finite=False)

--- a/ibench/benchmarks/svd.py
+++ b/ibench/benchmarks/svd.py
@@ -7,6 +7,7 @@ import scipy.linalg
 
 from .bench import Bench
 
+
 class Svd(Bench):
     sizes = {'large': 10000, 'small': 5000, 'tiny': 1000, 'test': 2}
 
@@ -14,7 +15,8 @@ class Svd(Bench):
         return (4./3.)*n*n*n*1e-9
 
     def _make_args(self, n):
-        self._A = np.asarray(np.random.rand(n,n), dtype=self._dtype)
+        self._A = np.asfortranarray(np.random.rand(n, n), dtype=self._dtype)
 
     def _compute(self):
-        scipy.linalg.svd(self._A, overwrite_a=True, check_finite=False, full_matrices=False)
+        scipy.linalg.svd(self._A, overwrite_a=True, check_finite=False,
+                         full_matrices=True)


### PR DESCRIPTION
Use asfortranarray for qr, svd.

Also, do out-of-place operation for SVD. While we can simply reuse the input array for some benchmarks, gesdd overwrites the input array with junk for `jobz != 'O'`, so MKL's SVD solver seems to terminate early, making timings look too good.