### PR TITLE
Perform copy in cholesky benchmark

### DIFF
--- a/ibench/benchmarks/cholesky.py
+++ b/ibench/benchmarks/cholesky.py
@@ -18,4 +18,5 @@ class Cholesky(Bench):
         self._A = np.asfortranarray(self._A*self._A.transpose() + n*np.eye(n))
 
     def _compute(self):
-        scipy.linalg.cholesky(self._A, lower=False, overwrite_a=True, check_finite=False)
+        scipy.linalg.cholesky(self._A, lower=False, overwrite_a=False,
+                              check_finite=False)

--- a/ibench/benchmarks/cholesky.py
+++ b/ibench/benchmarks/cholesky.py
@@ -7,6 +7,7 @@ import scipy.linalg
 
 from .bench import Bench
 
+
 class Cholesky(Bench):
     sizes = {'large': 40000, 'small': 10000, 'tiny': 2000, 'test': 2}
 
@@ -14,8 +15,8 @@ class Cholesky(Bench):
         return n*n*n/3.0*1e-9
 
     def _make_args(self, n):
-        self._A = np.asarray(np.random.rand(n,n), dtype=self._dtype)
-        self._A = np.asfortranarray(self._A*self._A.transpose() + n*np.eye(n))
+        self._A = np.asarray(np.random.rand(n, n), dtype=self._dtype)
+        self._A = np.asfortranarray(self._A.T @ self._A + n * np.eye(n))
 
     def _compute(self):
         scipy.linalg.cholesky(self._A, lower=False, overwrite_a=False,


### PR DESCRIPTION
- Avoid overwriting input to `scipy.linalg.cholesky`
- Actually perform matrix multiplication in cholesky `make_args` instead of elementwise multiplication